### PR TITLE
Remove extra configuration from codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,34 +20,25 @@ jobs:
         language: [ 'java-kotlin', 'javascript-typescript' ]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'adopt'
-        
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
 
-    - name: Perform CodeQL Analysis and Upload SARIF
-      id: codeql-analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        queries: |
-          languages/javascript/pointers
-          languages/java/pointers
-        paths: |
-          frontend
-          backend
-        # Pass the category based on the language being analyzed
-        additionalArguments: |
-          -D codeql.query.frontend=${{ matrix.language == 'javascript-typescript' }}
-          -D codeql.query.backend=${{ matrix.language == 'java-kotlin' }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
# Pull Request

## Description

Remove probably an extra piece of configuration from codeql.yml

```yaml

      with:
        queries: |
          languages/javascript/pointers
          languages/java/pointers
        paths: |
          frontend
          backend
        # Pass the category based on the language being analyzed
        additionalArguments: |
          -D codeql.query.frontend=${{ matrix.language == 'javascript-typescript' }}
          -D codeql.query.backend=${{ matrix.language == 'java-kotlin' }}
          
```

## Related Issue

#20 

## Checklist

Please review and check all applicable items:

- [x] I have tested my changes thoroughly
- [x] My code follows the project's coding standards and guidelines
- [x] I have reviewed my changes to ensure there are no unnecessary changes
- [x] My pull request has a descriptive title and includes a detailed description of the changes

## Additional Notes

The presence of the extra lines would not ruin our codeql analysis runs, but would remove the extra warnings

![image](https://github.com/daverbk/evolve/assets/98875282/9f9f1f0f-e8bf-4697-b572-6b67cf3efbca)

